### PR TITLE
Improved email hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@
   
 ---
 <h4 align="center">📫 How to reach me?</h4>
-  <h6 align="center">You may follow me on <a href="https://www.linkedin.com/in/chaitanya-liz-r-t-9471791b5/">LinkedIn</a> or on <a href="https://twitter.com/LizChaitanya">Twitter</a>.<br/>or send me mail at <a href="mailto:liz362002@gmail.com">liz362002@gmail.com</a> <br/> You can even create an issue <a href="https://github.com/CLiz17/CLiz17/issues/new">here</a>!</h6>
+  <h6 align="center">You may follow me on <a href="https://www.linkedin.com/in/chaitanya-liz-r-t-9471791b5/">LinkedIn</a> or on <a href="https://twitter.com/LizChaitanya">Twitter</a>.<br/>or send me mail at <a href="https://mail.google.com/mail/u/0/?fs=1&tf=cm&to=liz362002@gmail.com&body=-----------------------------Write+above+this+line------------------------------%0D%0AReferred+from+Github+Profile+Readme">liz362002@gmail.com</a> <br/> You can even create an issue <a href="https://github.com/CLiz17/CLiz17/issues/new">here</a>!</h6>


### PR DESCRIPTION
Most github users do not use mobile phones (for github) and most non-smartphone github users do not use email clients in desktops. And as we all know, most used email service in general is gmail. So, using a prefilled gmail link seems more sensible than a mailto tag as it allows more audience to email the intended identity in fewer clicks. And the small percentage of non-gmail users can just use the conventional way of copy pasting the email id, which they were already doing due to lack of email client in daily usage so the change will not affect their usage anyway. ;)